### PR TITLE
Updated C code to fix rare segfaults

### DIFF
--- a/src/ssw/ssw.c
+++ b/src/ssw/ssw.c
@@ -57,7 +57,7 @@
  *  Created by Mengyao Zhao on 6/22/10.
  *  Copyright 2010 Boston College. All rights reserved.
  *	Version 1.2.4
- *	Last revision by Mengyao Zhao on 2019-03-04.
+ *	Last revision by Mengyao Zhao on 2022-Apr-17.
  *
  *  The lazy-F loop implementation was derived from SWPS3, which is
  *  MIT licensed under ETH Zürich, Institute of Computational Science.
@@ -66,14 +66,19 @@
  *  BSD licensed under Micharl Farrar.
  */
 
-//#include <nmmintrin.h>
-#include <emmintrin.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
 #include "ssw.h"
+
+#ifdef __ARM_NEON // (M1)
+#include "sse2neon.h"
+#else // x86 (Intel)
+#include <emmintrin.h>
+#endif
+
 
 #ifdef __GNUC__
 #define LIKELY(x) __builtin_expect((x),1)
@@ -293,7 +298,7 @@ static alignment_end* sw_sse2_byte (const int8_t* ref,
 			vH = _mm_load_si128(pvHLoad + j);
 		}
 
-/* Lazy_F loop: has been revised to disallow adjecent insertion and then deletion, so don't update E(i, j), learn from SWPS3 */
+        /* Lazy_F loop: has been revised to disallow adjecent insertion and then deletion, so don't update E(i, j), learn from SWPS3 */
 		for (k = 0; LIKELY(k < 16); ++k) {
 			vF = _mm_slli_si128 (vF, 1);
 			for (j = 0; LIKELY(j < segLen); ++j) {
@@ -593,11 +598,12 @@ static cigar* banded_sw (const int8_t* ref,
 				 int32_t n) {
 
 	uint32_t *c = (uint32_t*)malloc(16 * sizeof(uint32_t)), *c1;
-	int32_t i, j, e, f, temp1, temp2, s = 16, s1 = 8, l, max = 0;
+	int32_t i, j, e, f, temp1, temp2, s = 16, s1 = 8, l, max = 0, len;
 	int64_t s2 = 1024;
 	char op, prev_op;
 	int32_t width, width_d, *h_b, *e_b, *h_c;
 	int8_t *direction, *direction_line;
+    len = refLen > readLen ? refLen : readLen;
 	cigar* result = (cigar*)malloc(sizeof(cigar));
 	h_b = (int32_t*)malloc(s1 * sizeof(int32_t));
 	e_b = (int32_t*)malloc(s1 * sizeof(int32_t));
@@ -613,13 +619,9 @@ static cigar* banded_sw (const int8_t* ref,
 			e_b = (int32_t*)realloc(e_b, s1 * sizeof(int32_t));
 			h_c = (int32_t*)realloc(h_c, s1 * sizeof(int32_t));
 		}
-		while (width_d * readLen * 3 >= s2) {
+		while (width_d * readLen * 3 >= s2) {   // width_d*readLen* overflow before s2
 			++s2;
 			kroundup32(s2);
-			if (s2 < 0) {
-				fprintf(stderr, "Alignment score and position are not consensus.\n");
-				exit(1);
-			}
 			direction = (int8_t*)realloc(direction, s2 * sizeof(int8_t));
 		}
 		direction_line = direction;
@@ -642,6 +644,7 @@ static cigar* banded_sw (const int8_t* ref,
 
 				temp1 = i == 0 ? -weight_gapO : h_b[e] - weight_gapO;
 				temp2 = i == 0 ? -weight_gapE : e_b[e] - weight_gapE;
+                //fprintf(stderr, "e_b length: %d, u: %d\n", s1, u);
 				e_b[u] = temp1 > temp2 ? temp1 : temp2;
 				direction_line[de] = temp1 > temp2 ? 3 : 2;
 
@@ -664,9 +667,12 @@ static cigar* banded_sw (const int8_t* ref,
 			for (j = 1; j <= u; j ++) h_b[j] = h_c[j];
 		}
 		band_width *= 2;
-	} while (LIKELY(max < score));
+	} while (max < score && band_width <= len); // 2022-Apr-08
 	band_width /= 2;
 
+    //if (max < score)
+	//	fprintf(stderr, "Warning: The alignment path of one pair of sequences may miss a small part. [ssw.c banded_sw]\n");
+    
 	// trace back
 	i = readLen - 1;
 	j = refLen - 1;
@@ -674,7 +680,7 @@ static cigar* banded_sw (const int8_t* ref,
 	l = 0;	// record length of current cigar
 	op = prev_op = 'M';
 	temp2 = 2;	// h
-	while (LIKELY(i > 0) || LIKELY(j > 0)) {
+	while (LIKELY(i > 0)) {
 		set_d(temp1, band_width, i, j, temp2);
 		switch (direction_line[temp1]) {
 			case 1:
@@ -713,7 +719,7 @@ static cigar* banded_sw (const int8_t* ref,
 				free(e_b);
 				free(h_b);
 				free(c);
-				free(result);
+				free(result); 
 				return 0;
 		}
 		if (op == prev_op) ++e;
@@ -831,6 +837,7 @@ s_align* ssw_align (const s_profile* prof,
 	r->read_begin1 = -1;
 	r->cigar = 0;
 	r->cigarLen = 0;
+    r->flag = 0;
 	if (maskLen < 15) {
 		fprintf(stderr, "When maskLen < 15, the function ssw_align doesn't return 2nd best alignment information.\n");
 	}
@@ -856,8 +863,8 @@ s_align* ssw_align (const s_profile* prof,
 		return NULL;
 	}
 	r->score1 = bests[0].score;
-	r->ref_end1 = bests[0].ref;
-	r->read_end1 = bests[0].read;
+	r->ref_end1 = bests[0].ref; // 0_based, always count from the input seq begin
+	r->read_end1 = bests[0].read;   // 0_based, count from the alignment begin (aligned length of the read)
 	if (maskLen >= 15) {
 		r->score2 = bests[1].score;
 		r->ref_end2 = bests[1].ref;
@@ -881,7 +888,14 @@ s_align* ssw_align (const s_profile* prof,
 	free(read_reverse);
 	r->ref_begin1 = bests_reverse[0].ref;
 	r->read_begin1 = r->read_end1 - bests_reverse[0].read;
-	free(bests_reverse);
+
+    if (UNLIKELY(r->score1 > bests_reverse[0].score)) { // banded_sw result will miss a small part
+		fprintf(stderr, "Warning: The alignment path of one pair of sequences may miss a small part. [ssw.c ssw_align]\n");
+        r->flag = 2;  
+    }
+    free(bests_reverse);
+
+//    fprintf(stderr, "1: %d, ref_end: %d, read_end: %d\n 2: %d, ref_end: %d, read_end: %d\n", r->score1, r->ref_end1, r->read_end1, bests_reverse[0].score, bests_reverse[0].ref, bests_reverse[0].read);
 	if ((7&flag) == 0 || ((2&flag) != 0 && r->score1 < filters) || ((4&flag) != 0 && (r->ref_end1 - r->ref_begin1 > filterd || r->read_end1 - r->read_begin1 > filterd))) goto end;
 
 	// Generate cigar.
@@ -889,11 +903,9 @@ s_align* ssw_align (const s_profile* prof,
 	readLen = r->read_end1 - r->read_begin1 + 1;
 	band_width = abs(refLen - readLen) + 1;
 	path = banded_sw(ref + r->ref_begin1, prof->read + r->read_begin1, refLen, readLen, r->score1, weight_gapO, weight_gapE, band_width, prof->mat, prof->n);
-	if (path == 0) {
-		free(r);
-		r = NULL;
-	}
-	else {
+	
+    if (path == 0) r->flag = 1;    // banded_sw is failed.
+    else {
 		r->cigar = path->seq;
 		r->cigarLen = path->length;
 		free(path);

--- a/src/ssw/ssw.h
+++ b/src/ssw/ssw.h
@@ -4,7 +4,7 @@
  *  Created by Mengyao Zhao on 6/22/10.
  *  Copyright 2010 Boston College. All rights reserved.
  *	Version 1.2.3
- *	Last revision by Mengyao Zhao on 11/29/16.
+ *	Last revision by Mengyao Zhao on 2022-Apr-15.
  *
  */
 
@@ -14,7 +14,13 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+
+#ifdef __ARM_NEON // (M1)
+#include "sse2neon.h"
+#else // x86 (Intel)
 #include <emmintrin.h>
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,18 +38,19 @@ struct _profile;
 typedef struct _profile s_profile;
 
 /*!	@typedef	structure of the alignment result
-	@field	score1	the best alignment score
-	@field	score2	sub-optimal alignment score
-	@field	ref_begin1	0-based best alignment beginning position on reference;	ref_begin1 = -1 when the best alignment beginning
+    @field	score1	the best alignment score
+    @field	score2	sub-optimal alignment score
+    @field	ref_begin1	0-based best alignment beginning position on reference;	ref_begin1 = -1 when the best alignment beginning
 						position is not available
-	@field	ref_end1	0-based best alignment ending position on reference
-	@field	read_begin1	0-based best alignment beginning position on read; read_begin1 = -1 when the best alignment beginning
+    @field	ref_end1	0-based best alignment ending position on reference
+    @field	read_begin1	0-based best alignment beginning position on read; read_begin1 = -1 when the best alignment beginning
 						position is not available
-	@field	read_end1	0-based best alignment ending position on read
-	@field	read_end2	0-based sub-optimal alignment ending position on read
-	@field	cigar	best alignment cigar; stored the same as that in BAM format, high 28 bits: length, low 4 bits: M/I/D (0/1/2);
+    @field	read_end1	0-based best alignment ending position on read
+    @field	read_end2	0-based sub-optimal alignment ending position on read
+    @field	cigar	best alignment cigar; stored the same as that in BAM format, high 28 bits: length, low 4 bits: M/I/D (0/1/2);
 					cigar = 0 when the best alignment path is not available
-	@field	cigarLen	length of the cigar string; cigarLen = 0 when the best alignment path is not available
+    @field	cigarLen	length of the cigar string; cigarLen = 0 when the best alignment path is not available
+    @field  flag  If the alignment path is accurate (or has missing part). 0: accurate; 1: banded_sw is totally failed; 2: banded_sw returned path has missing part
 */
 typedef struct {
 	uint16_t score1;
@@ -55,6 +62,7 @@ typedef struct {
 	int32_t ref_end2;
 	uint32_t* cigar;
 	int32_t cigarLen;
+    uint16_t flag;
 } s_align;
 
 /*!	@function	Create the query profile using the query sequence.

--- a/tests/test_ssw.py
+++ b/tests/test_ssw.py
@@ -137,5 +137,13 @@ class TestAlignment(unittest.TestCase):
         self.assertRaises(ValueError, ssw.Aligner, gap_open=1, gap_extend=2)
         self.assertRaises(ValueError, ssw.Aligner, gap_open=1, gap_extend=1)
 
+    def test_seg_fault(self):
+        #https://github.com/mengyao/Complete-Striped-Smith-Waterman-Library/issues/70
+        #causes segfault in older version of ssw
+        aligner = ssw.Aligner()
+        aligner.align("GATTGAAAAACTCCCAGGCTGGACACGGTGGCCCATGCCTGTAATCCCAGCACTCTGGGAGGCTGAGGTGGGCTGATCCCTTGAGGTCAGGAGTTCGAGACCATCCTGGAAAATGTGGCA",
+                   "AAAGGTGACCGGGCACGGTGGCCCATGCCTATAATCCCAGCACTTTGGGAGGCCCAGGCAGGTGGATCACTTGAGGTCAGGAGTTCGAGACCAGCCTGGC")
+        self.assertEqual(1,1)
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
https://github.com/mengyao/Complete-Striped-Smith-Waterman-Library/issues/70
There are certain sequence inputs that cause a segfault in the original ssw C code which have been fixed on the source repo. Here, I updated the ssw.c and ssw.h to the latest version as well as added a test for the segfault example.